### PR TITLE
Ajout resampling des `DiscreteLaw` 

### DIFF
--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,6 +1,6 @@
 
 export prodlaws, prodprocess
-export resample
+export resample, DiscreteLawSampler
 
 """
 Generate all permutations between discrete probabilities specified in args.
@@ -85,10 +85,58 @@ function prodprocess(wn::Vector{WhiteNoise})
     end
 end
 
+# raw resampling
 function resample(mu::DiscreteLaw, nbins::Int)
-    k = kmeans(mu.support', nbins, weights=weights(mu))
-    return DiscreteLaw(k.centers', k.cweights)
+    if nbins > 1
+        k = kmeans(mu.support', nbins, weights=weights(mu))
+        return DiscreteLaw(k.centers', k.cweights)
+    else
+        proba = weights(mu)
+        sup = zeros(Float64, 1, ndims(mu))
+        sup[:] = (mu.support' * proba)
+        return DiscreteLaw(sup, [1.])
+    end
 end
 
 resample(w::WhiteNoise, nbins::Int) = WhiteNoise(resample.(w.laws, nbins))
 resample(w::Vector{WhiteNoise}, nbins::Int) = resample(prodprocess(w), nbins)
+
+# resampler
+abstract type AbstractSampler end
+
+struct DiscreteLawSampler <: AbstractSampler
+    nbins::Int
+    nbins_inner::Int
+    Δn::Int
+end
+DiscreteLawSampler(nbins; nbins_inner=nbins, Δn=-1) = DiscreteLawSampler(nbins, nbins_inner, Δn)
+
+function (sampler::DiscreteLawSampler)(noises::Vector{WhiteNoise})
+    # if not specified, resample all in once
+    if (sampler.Δn == -1 ) || (sampler.Δn >= length(noises))
+        return resample(noises, sampler.nbins)
+    end
+
+    # otherwise, resample in two steps
+    nwindows = ceil(Int, length(noises) / sampler.Δn)
+    Δn = sampler.Δn
+
+    # ensure that total prodprocess size is not too big
+    @assert sampler.nbins_inner^nwindows <= 100_000
+
+    # first step
+    # we resample the noise sequentially
+    i0, i1 = 1, Δn
+
+    μtot = WhiteNoise[]
+
+    for nw in 1:nwindows
+        μ = resample(noises[i0:i1], sampler.nbins_inner)
+        push!(μtot, μ)
+        i0 += Δn
+        i1 = min(i1+Δn, length(noises))
+    end
+
+    # second step
+    return resample(μtot, sampler.nbins)
+end


### PR DESCRIPTION
Le but est de réduire la taille de la loi pour rendre la résolution plus rapide. 

A voir notamment : l'objet `DiscreteLawSampler`. 